### PR TITLE
Make SQLTableDataSet and SQLQueryDataSet usable

### DIFF
--- a/src/pipelinex/framework/context/flexible_catalog_context.py
+++ b/src/pipelinex/framework/context/flexible_catalog_context.py
@@ -69,7 +69,7 @@ class FlexibleCatalogContext(KedroContext):
         return ds_name, ds_dict
 
     def _set_filepath(self, ds_name, ds_dict):
-        if not any([(key in ds_dict) for key in ["filepath", "path", "url", "urls"]]):
+        if not any([(key in ds_dict) for key in ["filepath", "path", "url", "urls", "table_name", "sql"]]):
             ds_dict["filepath"] = ds_name
             ds_name = Path(ds_name).stem
         return ds_name, ds_dict


### PR DESCRIPTION
On original code, "filepath" added to SQLTableDataSet and SQLQueryDataSet, it's not permitted.
This fix prevent the issue.